### PR TITLE
Send on enter, auto scroll on new message

### DIFF
--- a/src/core/relay_pool.rs
+++ b/src/core/relay_pool.rs
@@ -31,6 +31,7 @@ impl RelayPoolTask {
     async fn handle_message(&mut self, msg: RelayPoolEv) {
         match msg {
             RelayPoolEv::ReceivedMsg { relay_url, msg } => {
+                // TODO: set up optional logging
                 dbg!(format!("Received message from {}: {:?}", &relay_url, &msg));
                 match msg {
                     RelayMessage::Event {
@@ -41,6 +42,7 @@ impl RelayPoolTask {
                         if let Ok(_) = event.verify() {
                             //Adds only new events
                             if let None = self.events.insert(event.id.to_string(), event.clone()) {
+                                // TODO: set up optional logging
                                 dbg!("New event, propagates");
                                 self.notification_sender
                                     .send(RelayPoolNotifications::ReceivedEvent { ev: event });

--- a/src/pages/chat/controller.rs
+++ b/src/pages/chat/controller.rs
@@ -1,7 +1,8 @@
 use druid::{
+    im::Vector,
     keyboard_types::Key,
-    widget::{Controller, TextBox},
-    Env, Event, EventCtx, Widget,
+    widget::{Controller, Scroll, TextBox},
+    Data, Env, Event, EventCtx, Rect, UpdateCtx, Widget,
 };
 
 use crate::{
@@ -16,11 +17,11 @@ pub struct ChatController {}
 
 impl ChatController {
     pub fn click_send_msg(ctx: &mut EventCtx, data: &mut AppState, _env: &Env) {
+        // TODO if we disable the send box when no convo is selected we don't need this guard
         if data.selected_conv.is_some() {
             let pk = data.selected_conv.clone().unwrap().contact.pk;
             let content = data.msg_to_send.clone();
             //TODO: Use chat new message instead
-            // let content = data.selected_conv.unwrap().new_message;
             ctx.submit_command(SEND_MSG.with(NewMessage::new(&pk, &content)));
 
             data.msg_to_send = "".into();
@@ -48,12 +49,11 @@ impl<W: Widget<AppState>> Controller<AppState, W> for OnEnterController {
         match event {
             Event::KeyUp(k_e) => {
                 if k_e.key == Key::Enter {
+                    // TODO if we disable the send box when no convo is selected we don't need this guard
                     if data.selected_conv.is_some() {
                         let pk = data.selected_conv.clone().unwrap().contact.pk;
                         let content = data.msg_to_send.clone();
                         let trimmed = content.trim_end();
-                        //TODO: Use chat new message instead
-                        // let content = data.selected_conv.unwrap().new_message;
                         ctx.submit_command(SEND_MSG.with(NewMessage::new(&pk, &trimmed)));
 
                         data.msg_to_send = "".into();
@@ -67,5 +67,29 @@ impl<W: Widget<AppState>> Controller<AppState, W> for OnEnterController {
         if (!ctx.is_handled()) {
             child.event(ctx, event, data, env);
         }
+    }
+}
+
+pub struct ConversationScrollController;
+
+impl<T: Data, W: Widget<Vector<T>>> Controller<Vector<T>, Scroll<Vector<T>, W>>
+    for ConversationScrollController
+{
+    fn update(
+        &mut self,
+        child: &mut Scroll<Vector<T>, W>,
+        ctx: &mut UpdateCtx,
+        old_data: &Vector<T>,
+        data: &Vector<T>,
+        env: &Env,
+    ) {
+        // TODO: Ideally we only do this when a new message arrives (could do a Command for this?)
+        if old_data.len() != data.len() {
+            // This scrolls to the bottom, but it scrolls to the bottom of the messages BEFORE the new one is added.
+            // So since it can't measure the new height, it can't scroll down far enough.
+            child.scroll_by((0.0, f64::INFINITY).into());
+            ctx.request_paint();
+        }
+        child.update(ctx, old_data, data, env);
     }
 }

--- a/src/pages/chat/controller.rs
+++ b/src/pages/chat/controller.rs
@@ -1,4 +1,8 @@
-use druid::{Env, EventCtx};
+use druid::{
+    keyboard_types::Key,
+    widget::{Controller, TextBox},
+    Env, Event, EventCtx, Widget,
+};
 
 use crate::{
     data::{
@@ -27,5 +31,41 @@ impl ChatController {
     }
     pub fn click_select_conv(ctx: &mut EventCtx, data: &mut ContactState, _env: &Env) {
         ctx.submit_command(SELECT_CONV.with(data.pk.clone()));
+    }
+}
+
+pub struct OnEnterController;
+
+impl<W: Widget<AppState>> Controller<AppState, W> for OnEnterController {
+    fn event(
+        &mut self,
+        child: &mut W,
+        ctx: &mut EventCtx,
+        event: &Event,
+        data: &mut AppState,
+        env: &Env,
+    ) {
+        match event {
+            Event::KeyUp(k_e) => {
+                if k_e.key == Key::Enter {
+                    if data.selected_conv.is_some() {
+                        let pk = data.selected_conv.clone().unwrap().contact.pk;
+                        let content = data.msg_to_send.clone();
+                        let trimmed = content.trim_end();
+                        //TODO: Use chat new message instead
+                        // let content = data.selected_conv.unwrap().new_message;
+                        ctx.submit_command(SEND_MSG.with(NewMessage::new(&pk, &trimmed)));
+
+                        data.msg_to_send = "".into();
+                    }
+                    ctx.set_handled()
+                }
+            }
+            _ => {}
+        }
+
+        if (!ctx.is_handled()) {
+            child.event(ctx, event, data, env);
+        }
     }
 }

--- a/src/pages/chat/view.rs
+++ b/src/pages/chat/view.rs
@@ -18,7 +18,7 @@ use crate::{
     theme::MONO_FONT,
 };
 
-use super::controller::OnEnterController;
+use super::controller::{ConversationScrollController, OnEnterController};
 
 pub fn chat_tab() -> impl Widget<AppState> {
     let root = Flex::column();
@@ -76,9 +76,11 @@ fn chat_conversation() -> impl Widget<ConversationState> {
         Flex::row()
             .with_flex_spacer(1.)
             .with_child(List::new(|| chat_message().fix_width(350.)).padding(10.))
-            .with_flex_spacer(1.),
+            .with_flex_spacer(1.)
+            .padding((0., 0., 0., 50.)),
     )
     .vertical()
+    .controller(ConversationScrollController)
     .lens(ConversationState::messages)
 }
 

--- a/src/pages/chat/view.rs
+++ b/src/pages/chat/view.rs
@@ -18,6 +18,8 @@ use crate::{
     theme::MONO_FONT,
 };
 
+use super::controller::OnEnterController;
+
 pub fn chat_tab() -> impl Widget<AppState> {
     let root = Flex::column();
 
@@ -58,7 +60,8 @@ fn input() -> impl Widget<AppState> {
         .with_font(MONO_FONT)
         .with_placeholder("Say hello")
         .expand_width()
-        .lens(AppState::msg_to_send);
+        .lens(AppState::msg_to_send)
+        .controller(OnEnterController);
 
     let send_btn = button("SEND").on_click(ChatController::click_send_msg);
 


### PR DESCRIPTION
this pr adds two new controllers to the conversation view

one of them watches for the enter key event to submit messages

the other one auto scrolls a chat to the bottom when a new message is added (with the caveat that the scroll event fires before the new message is added, not after, so it can't quite scroll down to the real bottom. adding a padding of 50 to the bottom makes it work well enough)